### PR TITLE
ai_edit: rename required param to continue_thread; enforce restore/no…

### DIFF
--- a/README.md
+++ b/README.md
@@ -623,6 +623,10 @@ https://github.com/user-attachments/assets/05670a7a-72c5-4276-925c-dbd1ed617d99
         },
         "description": "A list of file paths (relative to the repository root) that Aider should operate on. This argument is mandatory."
       },
+      "continue_thread": {
+        "type": "boolean",
+        "description": "Required. Whether to continue the Aider thread by restoring chat history. If true, passes --restore-chat-history; if false, passes --no-restore-chat-history. Clients must explicitly choose."
+      },
       "options": {
         "type": "array",
         "items": {
@@ -645,7 +649,8 @@ https://github.com/user-attachments/assets/05670a7a-72c5-4276-925c-dbd1ed617d99
     "required": [
       "repo_path",
       "message",
-      "files"
+      "files",
+      "continue_thread"
     ]
   }
   ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-devtools"
-version = "1.2.7"
+version = "1.3.0"
 authors = [
   { name="daoch4n", email="daoch4n@gmail.com" },
 ]

--- a/test_server.py
+++ b/test_server.py
@@ -337,10 +337,8 @@ async def test_write_to_file_content_bytes_mismatch_and_exception(tmp_path, monk
         raise Exception("write error")
     monkeypatch.setattr(builtins, "open", raise_exc_open)
     result_exc = await write_to_file_content(str(tmp_path), "fail.txt", "fail")
-    assert (
-        "UNEXPECTED_ERROR: Failed to write to file 'fail.txt': write error. AI_HINT: Check file permissions, disk space, and review server logs for more details."
-        in result_exc
-    )
+    assert "UNEXPECTED_ERROR: Failed to write to file 'fail.txt': write error" in result_exc
+    assert "UNEXPECTED_ERROR:" in result_exc
 
 @pytest.mark.asyncio
 async def test_execute_custom_command_exception(monkeypatch, tmp_path):
@@ -351,10 +349,8 @@ async def test_execute_custom_command_exception(monkeypatch, tmp_path):
         raise Exception("subprocess error")
     monkeypatch.setattr(asyncio, "create_subprocess_shell", raise_exc)
     result = await execute_custom_command(str(tmp_path), "echo fail")
-    assert (
-        "UNEXPECTED_ERROR: Failed to execute command 'echo fail': subprocess error. AI_HINT: Check the command syntax, permissions, and review server logs for more details."
-        in result
-    )
+    assert "UNEXPECTED_ERROR: Failed to execute command 'echo fail': subprocess error" in result
+    assert "UNEXPECTED_ERROR:" in result
 
 @patch('server._generate_diff_output', new_callable=AsyncMock)
 @patch('server._run_tsc_if_applicable', new_callable=AsyncMock)
@@ -542,10 +538,8 @@ async def test_search_and_replace_in_file_fallback_on_exception(tmp_path, monkey
     result = await search_and_replace_in_file(
         str(tmp_path), "foo", "qux", "exc_file.txt", False, None, None
     )
-    assert (
-        "UNEXPECTED_ERROR: An unexpected error occurred during sed-based search and replace: sed open error. AI_HINT: Check your search/replace patterns, file permissions, and review server logs for more details."
-        in result
-    )
+    assert "UNEXPECTED_ERROR: An unexpected error occurred during sed-based search and replace: sed open error" in result
+    assert "UNEXPECTED_ERROR:" in result
     # The file should remain unchanged due to the error
     assert (file_path).read_text() == "foo bar baz"
 
@@ -1086,7 +1080,7 @@ async def test_git_apply_diff_cases(monkeypatch, tmp_path):
     )
     result = await git_apply_diff(repo, diff_content)
     assert (
-        "GIT_COMMAND_FAILED: Failed to apply diff. Details: \n  stderr: 'git error'. AI_HINT: Check if the diff is valid and applies cleanly to the current state of the repository."
+        "GIT_COMMAND_FAILED: Failed to apply diff. Details: \n  stderr: 'git error'. Check if the diff is valid and applies cleanly to the current state of the repository."
         in result
     )
 
@@ -1122,7 +1116,5 @@ def test_git_read_file_error_cases(monkeypatch):
         raise Exception("fail")
     monkeypatch.setattr("builtins.open", fake_open_exc)
     result = git_read_file(repo, "nofile.txt")
-    assert (
-        "UNEXPECTED_ERROR: Failed to read file 'nofile.txt': fail. AI_HINT: Check if the file exists, is accessible, and not corrupted. Review server logs for more details."
-        in result
-    )
+    assert "UNEXPECTED_ERROR: Failed to read file 'nofile.txt': fail" in result
+    assert "UNEXPECTED_ERROR:" in result


### PR DESCRIPTION
…-restore flag; bump version to 1.3.0; add dynamic repo_path guidance; extract guidance into helper functions and remove 'AI_HINT:' prefix; refine guidance across tools; update tests and README
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Renames `required` to `continue_thread`, enforces `restore/no-restore` flag, updates version to 1.3.0, refines error handling, and updates tests.
> 
>   - **Behavior**:
>     - Renames `required` parameter to `continue_thread` in `README.md` and `server.py`.
>     - Enforces `restore/no-restore` flag in `ai_edit_files()` in `server.py`.
>     - Updates version to `1.3.0` in `pyproject.toml`.
>   - **Guidance and Error Handling**:
>     - Adds dynamic `repo_path` guidance in `call_tool()` in `server.py`.
>     - Extracts guidance into helper functions like `ai_hint_git_apply_diff_error()` in `server.py`.
>     - Refines guidance across tools in `server.py`.
>   - **Tests**:
>     - Updates tests in `test_server.py` to reflect changes in error messages and parameter requirements.
>     - Adjusts assertions to match new error handling logic.
>   - **Misc**:
>     - Removes 'AI_HINT:' prefix from error messages in `server.py`.
>     - Minor updates to `README.md` to reflect parameter changes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=daoch4n%2Fmcp-devtools&utm_source=github&utm_medium=referral)<sup> for 374877caa21fc57c802e392926d720302cbbf52b. You can [customize](https://app.ellipsis.dev/daoch4n/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->