### PR TITLE
Adds path filtering to git_diff function and updates related components and tests: enable users to limit git diff output to specific files or directories, making the tool more flexible for targeted code reviews.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "mcp-devtools"
-version = "1.7.4"
+version = "1.7.5"
 authors = [
   { name="daoch4n", email="daoch4n@gmail.com" },
 ]

--- a/server.py
+++ b/server.py
@@ -1499,7 +1499,7 @@ async def call_tool(name: str, arguments: dict) -> list[Content]:
                     diff = git_diff(repo, target, path)
                     diff_header = f"Diff with {target}:" if target else "Diff of unstaged changes (worktree vs index):"
                     if path:
-                        diff_header = diff_header[:-1] + f" for path {path}:"
+                        diff_header = f"Diff with {target} for path {path}:" if target else f"Diff of unstaged changes (worktree vs index) for path {path}:"
                     return [TextContent(
                         type="text",
                         text=f"{diff_header}\n{diff}"

--- a/server.py
+++ b/server.py
@@ -544,10 +544,10 @@ def git_diff(repo: git.Repo, target: Optional[str] = None, path: Optional[str] =
     Returns:
         A string representing the output of `git diff` or `git diff <target>`.
     """
-    if target is None:
-        return repo.git.diff() if path is None else repo.git.diff('--', path)
-    else:
-        return repo.git.diff(target) if path is None else repo.git.diff(target, '--', path)
+    args = [target] if target else []
+    if path:
+        args.extend(['--', path])
+    return repo.git.diff(*args)
 
 def git_stage_and_commit(repo: git.Repo, message: str, files: Optional[List[str]] = None) -> str:
     """

--- a/test_server.py
+++ b/test_server.py
@@ -267,6 +267,33 @@ def test_git_read_file(temp_git_repo):
 #     assert "Diff was too large (over 1000 lines)." in large_diff_output
 
 @pytest.mark.asyncio
+async def test_git_diff_path_filter(temp_git_repo):
+    repo, repo_path = temp_git_repo
+    
+    # Create and modify two files
+    (repo_path / "a.txt").write_text("content a")
+    (repo_path / "b.txt").write_text("content b")
+    repo.index.add(["a.txt", "b.txt"])
+    repo.index.commit("Add files")
+    
+    # Modify both files
+    (repo_path / "a.txt").write_text("modified content a")
+    (repo_path / "b.txt").write_text("modified content b")
+    
+    # Test diff with path filter for a.txt (unstaged changes)
+    diff_a = git_diff(repo, None, path="a.txt")
+    assert "+modified content a" in diff_a
+    assert "b.txt" not in diff_a
+    
+    # Stage a.txt
+    repo.index.add(["a.txt"])
+    
+    # Test diff with path filter for a.txt against HEAD (staged changes)
+    diff_a_staged = git_diff(repo, "HEAD", path="a.txt")
+    assert "+modified content a" in diff_a_staged
+    assert "b.txt" not in diff_a_staged
+
+@pytest.mark.asyncio
 async def test_generate_diff_output_empty_diff():
     from server import _generate_diff_output
     original = "foo\nbar\nbaz"
@@ -445,6 +472,11 @@ async def test_call_tool(
     mock_git_diff.return_value = "diff_default_output"
     result = list(await call_tool(GitTools.DIFF.value, {"repo_path": "/tmp/repo"}))
     assert result[0].text == "Diff of unstaged changes (worktree vs index):\ndiff_default_output"
+
+    # Test GitTools.DIFF without target but with path
+    mock_git_diff.return_value = "diff_path_output"
+    result = list(await call_tool(GitTools.DIFF.value, {"repo_path": "/tmp/repo", "path": "foo.txt"}))
+    assert result[0].text == "Diff of unstaged changes (worktree vs index) for path foo.txt:\ndiff_path_output"
 
     # Test GitTools.COMMIT
     mock_git_stage_and_commit.return_value = "Commit successful"

--- a/test_server.py
+++ b/test_server.py
@@ -266,8 +266,7 @@ def test_git_read_file(temp_git_repo):
 #     large_diff_output = await _generate_diff_output(large_original, large_new, file_path)
 #     assert "Diff was too large (over 1000 lines)." in large_diff_output
 
-@pytest.mark.asyncio
-async def test_git_diff_path_filter(temp_git_repo):
+def test_git_diff_path_filter(temp_git_repo):
     repo, repo_path = temp_git_repo
     
     # Create and modify two files


### PR DESCRIPTION
1. Added optional `path` parameter to `GitDiff` model and `git_diff()` function
2. Updated `git_diff()` implementation to support path filtering using `git diff -- <path>`
3. Modified `call_tool()` to handle the new path parameter and update diff headers accordingly
4. Added test case `test_git_diff_path_filter` to verify path filtering functionality
5. Updated tool description to mention path filter support
6. Added test case in `test_call_tool` for DIFF with path but no target

The changes enable users to limit git diff output to specific files or directories, making the tool more flexible for targeted code reviews.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds path filtering to `git_diff` function and updates related components and tests.
> 
>   - **Behavior**:
>     - Adds optional `path` parameter to `GitDiff` model and `git_diff()` function to filter diffs by file or directory.
>     - Updates `git_diff()` in `server.py` to use `git diff -- <path>` for path filtering.
>     - Modifies `call_tool()` in `server.py` to handle `path` parameter and update diff headers.
>   - **Tests**:
>     - Adds `test_git_diff_path_filter` in `test_server.py` to verify path filtering.
>     - Adds test case in `test_call_tool` for DIFF with path but no target.
>   - **Documentation**:
>     - Updates tool description in `server.py` to mention path filter support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=daoch4n%2Fmcp-devtools&utm_source=github&utm_medium=referral)<sup> for 3302812555c48b499cb591295135ae74fce915e1. You can [customize](https://app.ellipsis.dev/daoch4n/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->